### PR TITLE
Add depends_on

### DIFF
--- a/posts/asyncio-create-task.md
+++ b/posts/asyncio-create-task.md
@@ -2,6 +2,9 @@
 author: orsinium
 traces:
   - [module: asyncio, function: create_task]
+depends_on:
+  - asyncio-run
+  - asyncio-sleep
 ---
 
 # asyncio.create_task

--- a/posts/asyncio-gather.md
+++ b/posts/asyncio-gather.md
@@ -2,6 +2,9 @@
 author: orsinium
 traces:
   - [module: asyncio, function: gather]
+depends_on:
+  - asyncio-run
+  - asyncio-sleep
 ---
 
 # asyncio.gather

--- a/posts/asyncio-run.md
+++ b/posts/asyncio-run.md
@@ -2,6 +2,8 @@
 author: orsinium
 traces:
   - [module: asyncio, function: run]
+depends_on:
+  - asyncio
 ---
 
 # asyncio.run

--- a/posts/asyncio-sleep.md
+++ b/posts/asyncio-sleep.md
@@ -2,6 +2,9 @@
 author: orsinium
 traces:
   - [module: asyncio, function: sleep]
+depends_on:
+  - asyncio
+  - asyncio-run
 ---
 
 # asyncio.sleep

--- a/posts/build-system.md
+++ b/posts/build-system.md
@@ -3,6 +3,8 @@ author: orsinium
 topics:
   - packaging
 pep: 518
+depends_on:
+  - pyproject-toml
 ---
 
 # build-system

--- a/posts/contextlib-chdir.md
+++ b/posts/contextlib-chdir.md
@@ -3,6 +3,8 @@ author: orsinium
 traces:
   - [{module: contextlib}, {function: chdir}]
 python: "3.11"
+depends_on:
+  - os-curdir
 ---
 
 # contextlib.chdir

--- a/posts/except-star-2.md
+++ b/posts/except-star-2.md
@@ -4,6 +4,9 @@ traces:
   - [{exception: ExceptionGroup}]
 pep: 654
 python: "3.11"
+depends_on:
+  - except-star
+  - exception-group
 ---
 
 # `except*` for regular exceptions

--- a/posts/except-star.md
+++ b/posts/except-star.md
@@ -4,6 +4,8 @@ traces:
   - [{exception: ExceptionGroup}]
 pep: 654
 python: "3.11"
+depends_on:
+  - exception-group
 ---
 
 # `except*`

--- a/posts/generic-types.md
+++ b/posts/generic-types.md
@@ -2,6 +2,8 @@
 published: 2020-06-09
 id: 569
 author: orsinium
+topics:
+  - typing
 pep: 585
 python: "3.9"
 ---

--- a/posts/reveal-type.md
+++ b/posts/reveal-type.md
@@ -9,7 +9,7 @@ python: "3.11"
 
 # reveal_type
 
-The `reveal_type` function doesn't exist. However, if you call it and then run a type-checker (like [mypy](https://mypy.readthedocs.io/) or pyright) on the file, it will show the type of the passed object:
+The `reveal_type` function doesn't exist. However, if you call it and then run a type-checker (like [mypy](https://mypy.readthedocs.io/) or [pyright](https://github.com/microsoft/pyright)) on the file, it will show the type of the passed object:
 
 ```python
 a = 1

--- a/posts/tomllib.md
+++ b/posts/tomllib.md
@@ -3,6 +3,8 @@ author: orsinium
 traces:
   - [{module: tomllib}]
 pep: 680
+depends_on:
+  - pyproject-toml
 ---
 
 # tomllib

--- a/posts/typing-self.md
+++ b/posts/typing-self.md
@@ -8,7 +8,7 @@ python: "3.11"
 
 # typing.Self
 
-As we covered earlier, if the result of a base class is the current class, a `TypeVar` should be used as the annotation:
+[As we covered a 3 years back](https://t.me/pythonetc/451) (gosh, the channel is old), if the result of a base class is the current class, a `TypeVar` should be used as the annotation:
 
 ```python
 from typing import TypeVar

--- a/sdk/commands/_html.py
+++ b/sdk/commands/_html.py
@@ -37,6 +37,7 @@ class HTMLCommand(Command):
             published = post.published or today
             years[published.year].append(post)
         render_html('index', pages=PAGES, years=sorted(years.items()))
+        render_html('typing', posts=posts, title='typing')
 
         pythons = sorted(
             {post.python for post in posts if post.python},

--- a/sdk/pages.py
+++ b/sdk/pages.py
@@ -23,4 +23,8 @@ PAGES: tuple[Page, ...] = (
         'stdlib', 'stdlib.html',
         'Posts covering specific modules or function in stdlib.',
     ),
+    Page(
+        'typing', 'typing.html',
+        'Posts about type annotations.',
+    ),
 )

--- a/sdk/post.py
+++ b/sdk/post.py
@@ -56,6 +56,7 @@ class Post:
     traces: list[Trace] = field(default_factory=list)
     pep: int | None = None
     topics: list[str] = field(default_factory=list)
+    depends_on: list[str] = field(default_factory=list)
     published: date | None = None
     python: str | None = None
     chain: PostChain | None = None

--- a/sdk/post.py
+++ b/sdk/post.py
@@ -120,6 +120,12 @@ class Post:
     def url(self) -> str:
         return f'posts/{self.slug}.html'
 
+    @property
+    def is_typing(self) -> bool:
+        if 'typing' in self.topics:
+            return True
+        return any(trace.module_name == 'typing' for trace in self.traces)
+
     @cached_property
     def pep_info(self) -> PEP | None:
         if self.pep is None:

--- a/sdk/schema.json
+++ b/sdk/schema.json
@@ -37,6 +37,13 @@
             "type": "string",
             "minLength": 3
         },
+        "depends_on": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 4
+            }
+        },
         "traces": {
             "type": "array",
             "items": {

--- a/templates/typing.html.j2
+++ b/templates/typing.html.j2
@@ -1,0 +1,17 @@
+{% extends "base.html.j2" %}
+{% block content %}
+  <ul>
+    {% for post in posts %}
+      {% if post.is_typing %}
+        <li>
+          <span class="text-muted">
+            {{ post.published }}
+          </span>
+          <a href="{{ post.url }}">
+            {{ post.title }}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endblock %}


### PR DESCRIPTION
1. Add depends_on to the upcoming posts. It currently doesn't do anything in the SDK, just a little reminder for me what posts should go in what order.
2. Add "typing" page in the HTML that shows all posts about type annotations.