### PR TITLE
schedule python 3.11 posts

### DIFF
--- a/posts/add-note.md
+++ b/posts/add-note.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-01
 traces:
   - [{type: BaseException}, {method: add_note}]
 pep: 678
@@ -8,7 +9,7 @@ python: "3.11"
 
 # BaseException.add_note
 
-[PEP 678](https://peps.python.org/pep-0678/) (landed in Python 3.11) introduced a new method `add_note` for `BaseException` class. You can call it on any exception to provice additional context which will be shown at the end of the traceback for the exception:
+[PEP 678](https://peps.python.org/pep-0678/) (landed in Python 3.11) introduced a new method `add_note` for `BaseException` class. You can call it on any exception to provide additional context which will be shown at the end of the traceback for the exception:
 
 ```python
 try:

--- a/posts/assert-type.md
+++ b/posts/assert-type.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-29
 traces:
   - [module: typing, function: assert_type]
 python: "3.11"
@@ -7,7 +8,7 @@ python: "3.11"
 
 # typing.assert_type
 
-The `typing.assert_type` function does nothing in runtime as most of the stuff from the `typing` module. However, if the type of the first argument doesn't match the type provided as the second argument, the type checker will return an error. It can be useful to write simple "tests" for your library to ensure it is well annotated.
+The `typing.assert_type` function (added in Python 3.11) does nothing in runtime as most of the stuff from the `typing` module. However, if the type of the first argument doesn't match the type provided as the second argument, the type checker will return an error. It can be useful to write simple "tests" for your library to ensure it is well annotated.
 
 For example, you have a library that defines a lot of decorators, like this:
 

--- a/posts/contextlib-chdir.md
+++ b/posts/contextlib-chdir.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-22
 traces:
   - [{module: contextlib}, {function: chdir}]
 python: "3.11"
@@ -9,7 +10,7 @@ depends_on:
 
 # contextlib.chdir
 
-I often find myself making a special context manager to temporarily change the current working directory:
+I often find myself writing a context manager to temporarily change the current working directory:
 
 ```python
 import os

--- a/posts/dataclass-transform.md
+++ b/posts/dataclass-transform.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-12-06
 pep: 681
 python: "3.11"
 traces:
@@ -8,4 +9,4 @@ traces:
 
 # typing.dataclass_transform
 
-[PEP 681](https://peps.python.org/pep-0681/) introduced `typing.dataclass_transform` decorator. It can be used to mark a class that behaves like a dataclass. The type checker will assume that it has `__init__` that accepts annotated attributes as arguments, `__eq__`, `__ne__`, and `__str__`. For example, it can be used to annotate [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy) or [Django](https://github.com/django/django) models, [attrs](https://github.com/python-attrs/attrs) classes, [pydantic](https://github.com/pydantic/pydantic) validators, and so on. It's useful not only for libraries that don't provide a mypy plugin but also if you use a non-mypy type checker. For instance, [pyright](https://github.com/microsoft/pyright), which is used by vscode Python plugin to show types, highlight syntax, provide autocomplete, and so on.
+[PEP 681](https://peps.python.org/pep-0681/) (landed in Python 3.11) introduced `typing.dataclass_transform` decorator. It can be used to mark a class that behaves like a dataclass. The type checker will assume that it has `__init__` that accepts annotated attributes as arguments, `__eq__`, `__ne__`, and `__str__`. For example, it can be used to annotate [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy) or [Django](https://github.com/django/django) models, [attrs](https://github.com/python-attrs/attrs) classes, [pydantic](https://github.com/pydantic/pydantic) validators, and so on. It's useful not only for libraries that don't provide a mypy plugin but also if you use a non-mypy type checker. For instance, [pyright](https://github.com/microsoft/pyright), which is used by vscode Python plugin to show types, highlight syntax, provide autocomplete, and so on.

--- a/posts/except-star-2.md
+++ b/posts/except-star-2.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-17
 traces:
   - [{exception: ExceptionGroup}]
 pep: 654
@@ -11,7 +12,7 @@ depends_on:
 
 # `except*` for regular exceptions
 
-One more thing you should know about `except*`. It can match not only sub-exceptions from `ExceptionGroup` but regular exceptions too. And for simplicity of handling, regular exceptions will be wrapped into `ExceptionGroup`:
+There is one more thing you should know about `except*`. It can match not only sub-exceptions from `ExceptionGroup` but regular exceptions too. And for simplicity of handling, regular exceptions will be wrapped into `ExceptionGroup`:
 
 ```python
 try:

--- a/posts/except-star.md
+++ b/posts/except-star.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-15
 traces:
   - [{exception: ExceptionGroup}]
 pep: 654
@@ -41,7 +42,7 @@ caught2: ExceptionGroup('', [ValueError()])
     +------------------------------------
 ```
 
-Here is what happened:
+This is what happened:
 
 1. When `ExceptionGroup` is raised, it's checked against each `except*` block.
 2. `except* KeyError` block catches `ExceptionGroup` that contains `KeyError`.

--- a/posts/exception-group.md
+++ b/posts/exception-group.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-11-08
 traces:
   - [{exception: ExceptionGroup}]
 pep: 654

--- a/posts/isinstance.md
+++ b/posts/isinstance.md
@@ -2,6 +2,8 @@
 author: orsinium
 traces:
   - [{function: isinstance}]
+depends_on:
+  - reveal-type
 ---
 
 # isinstance

--- a/posts/literal-string.md
+++ b/posts/literal-string.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-12-27
 pep: 675
 python: "3.11"
 traces:

--- a/posts/os-curdir.md
+++ b/posts/os-curdir.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-10-18
 traces:
   - [{module: os}, {function: curdir}]
   - [{module: os}, {function: getcwd}]

--- a/posts/python-3-11.md
+++ b/posts/python-3-11.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-10-24
 topics:
   - news
 python: "3.11"

--- a/posts/reveal-type.md
+++ b/posts/reveal-type.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-12-20
 topics:
   - typing
 traces:

--- a/posts/traceback-col.md
+++ b/posts/traceback-col.md
@@ -1,6 +1,8 @@
 ---
 author: orsinium
+published: 2022-10-25
 pep: 657
+python: "3.11"
 ---
 
 # Column in tracebacks

--- a/posts/typing-self.md
+++ b/posts/typing-self.md
@@ -1,5 +1,6 @@
 ---
 author: orsinium
+published: 2022-12-03
 traces:
   - [{module: typing}, {type: Self}]
 pep: 673


### PR DESCRIPTION
```
2022-10-18 |          |      | os-curdir.md               | os.curdir
2022-10-24 |          | 3.11 | python-3-11.md             | Python 3.11
2022-10-25 | PEP 657  | 3.11 | traceback-col.md           | Column in tracebacks
2022-11-01 | PEP 678  | 3.11 | add-note.md                | BaseException.add_note
2022-11-08 | PEP 654  | 3.11 | exception-group.md         | ExceptionGroup
2022-11-15 | PEP 654  | 3.11 | except-star.md             | `except*`
2022-11-17 | PEP 654  | 3.11 | except-star-2.md           | `except*` for regular exceptions
2022-11-22 |          | 3.11 | contextlib-chdir.md        | contextlib.chdir
2022-11-29 |          | 3.11 | assert-type.md             | typing.assert_type
2022-12-03 | PEP 673  | 3.11 | typing-self.md             | typing.Self
2022-12-06 | PEP 681  | 3.11 | dataclass-transform.md     | typing.dataclass_transform
2022-12-20 |          | 3.11 | reveal-type.md             | reveal_type
2022-12-27 | PEP 675  | 3.11 | literal-string.md          | typing.LiteralString
```