### PR TITLE
Add GitHub Actions cron job that triggers Netlify

### DIFF
--- a/.github/workflows/daily-builds.yml
+++ b/.github/workflows/daily-builds.yml
@@ -1,0 +1,12 @@
+name: Daily Netlify builds
+on:
+  schedule:
+    - cron: "30 16 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Netlify build using webhook
+        run: curl -s -X POST "$NETLIFY_BUILD_HOOK_URL"
+        env:
+          NETLIFY_BUILD_HOOK_URL: "${{ secrets.NETLIFY_BUILD_HOOK_URL }}"


### PR DESCRIPTION
Based on this blog post:
https://www.voorhoede.nl/en/blog/scheduling-netlify-deploys-with-github-actions/

Let's see if it works. This is required for having RSS updated daily.